### PR TITLE
[t-mr1] PlatformConfig: Update earlycon serial port address

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -26,7 +26,7 @@ BOARD_KERNEL_TAGS_OFFSET := 0x00000100
 BOARD_RAMDISK_OFFSET     := 0x01000000
 
 # Serial console
-#BOARD_KERNEL_CMDLINE += earlycon=msm_geni_serial,0xa90000
+#BOARD_KERNEL_CMDLINE += earlycon=msm_geni_serial,0xa9c000
 
 BOARD_BOOTCONFIG += androidboot.usbcontroller=a600000.dwc3
 


### PR DESCRIPTION
On Kalama SoC UART interface located on qupv3_se7_2uart and has 0xa9c000 address.