### PR TITLE
[U] vintf/keymint: Split `IRemotelyProvisionedComponent` out from `IKeyMintDevice`

### DIFF
--- a/vintf/android.hardware.security.keymint-service-qti.xml
+++ b/vintf/android.hardware.security.keymint-service-qti.xml
@@ -3,6 +3,10 @@
         <name>android.hardware.security.keymint</name>
         <version>2</version>
         <fqname>IKeyMintDevice/default</fqname>
+    </hal>
+    <hal format="aidl">
+        <name>android.hardware.security.keymint</name>
+        <version>2</version>
         <fqname>IRemotelyProvisionedComponent/default</fqname>
     </hal>
     <hal format="aidl">


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/836
CC @paulbouchara

Since Android U the `IRemotelyProvisionedComponent` was [split out] from `IKeyMintDevice` inside `keymint` into a different `../rkp` folder (and manifest definition) inside the `hardware/interfaces` repository.  The build on U now complains that it doesn't like our current simplification of having both services defined inside the same `<hal>` element:

    HAL manifest entries must only contain interfaces from the same aidl_interface
        android.hardware.security.keymint.IKeyMintDevice is in android.hardware.security.keymint
        android.hardware.security.keymint.IRemotelyProvisionedComponent is from another AIDL interface module

This is easy to fix by splitting the bundled `fqname`s for both interfaces.  The "domain" or "package name" remains the same for ABI compatibility.

[split out]: https://cs.android.com/android/_/android/platform/hardware/interfaces/+/ca73d57c8379a82212a2fc91585c9f13b9b44a9b
