### PR TITLE
[t-mr1] platform: Update BT SoC name to Hamilton

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -385,11 +385,11 @@ PRODUCT_PACKAGES += \
     android.hardware.bluetooth@1.0-service-qti
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    persist.vendor.qcom.bluetooth.soc=hastings
+    persist.vendor.qcom.bluetooth.soc=hamilton
 
 # Legacy BT property (will be removed in S)
 PRODUCT_PROPERTY_OVERRIDES += \
-    vendor.qcom.bluetooth.soc=hastings
+    vendor.qcom.bluetooth.soc=hamilton
 
 # Audio - Android System
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
SoC Kalama BT chipset is Hamliton.

https://github.com/sonyxperiadev/kernel-techpack-bt-kernel/commit/cc92023f48768c7bfba04609a4e5580c85277db8