### PR TITLE
[u-mr1] README.md: Update Sony Open Devices domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Android device configuration for the yodo platform (**SM8550**).
 
 ### Build instructions
 
-https://developer.sony.com/develop/open-devices/guides/aosp-build-instructions/
+https://opendevices.sony.net/aosp-on-xperia-open-devices/guides/aosp-build-instructions/


### PR DESCRIPTION
Sony's Developer World closed down on 8 May, 2026.
AOSP on Xperia Open Devices have moved to dedicated
https://opendevices.sony.net/ website.